### PR TITLE
=BG= SUPPORTS_COLOR environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,11 @@ module.exports = (function () {
 		return false;
 	}
 
+	if (!!process.env.SUPPORTS_COLOR) {
+		//May also flag via environment variable instead of command line flag
+		return true;
+	}
+
 	if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
 		return true;
 	}


### PR DESCRIPTION
- as an alternative to the `--color` CLI flag
- useful in scenarios when an environment variable is more apt