### PR TITLE
=BG= SUPPORTS_COLOR environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,10 @@ module.exports = (function () {
 		return false;
 	}
 
+	if ('SUPPORTS_COLOR' in process.env) {
+		return true;
+	}
+
 	if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
 		return true;
 	}


### PR DESCRIPTION
- as an alternative to the `--color` CLI flag
- useful in scenarios when an environment variable is more apt
- this time following the convention for checking the prop