### PR TITLE
Added support for British "colour" spelling

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,20 +2,27 @@
 var argv = process.argv;
 
 module.exports = (function () {
-	if ('FORCE_COLOR' in process.env) {
+	if ('FORCE_COLOR' in process.env || 'FORCE_COLOUR' in process.env) {
 		return true;
 	}
 
 	if (argv.indexOf('--no-color') !== -1 ||
+		argv.indexOf('--no-colour') !== -1 ||
 		argv.indexOf('--no-colors') !== -1 ||
-		argv.indexOf('--color=false') !== -1) {
+		argv.indexOf('--no-colours') !== -1 ||
+		argv.indexOf('--color=false') !== -1 ||
+		argv.indexOf('--colour=false') !== -1) {
 		return false;
 	}
 
 	if (argv.indexOf('--color') !== -1 ||
+		argv.indexOf('--colour') !== -1 ||
 		argv.indexOf('--colors') !== -1 ||
+		argv.indexOf('--colours') !== -1 ||
 		argv.indexOf('--color=true') !== -1 ||
-		argv.indexOf('--color=always') !== -1) {
+		argv.indexOf('--colour=true') !== -1 ||
+		argv.indexOf('--color=always') !== -1 ||
+		argv.indexOf('--colour=always') !== -1) {
 		return true;
 	}
 

--- a/test.js
+++ b/test.js
@@ -12,6 +12,10 @@ it('should return true if `FORCE_COLOR` is in env', function () {
 	process.env.FORCE_COLOR = true;
 	assert.equal(requireUncached('./'), true);
 });
+it('should return true if `FORCE_COLOUR` is in env', function () {
+	process.env.FORCE_COLOUR = true;
+	assert.equal(requireUncached('./'), true);
+});
 
 it('should return false if not TTY', function () {
 	process.stdout.isTTY = false;
@@ -22,9 +26,17 @@ it('should return false if --no-color flag is used', function () {
 	process.argv = ['--no-color'];
 	assert.equal(requireUncached('./'), false);
 });
+it('should return false if --no-colour flag is used', function () {
+	process.argv = ['--no-colour'];
+	assert.equal(requireUncached('./'), false);
+});
 
 it('should return false if --no-colors flag is used', function () {
 	process.argv = ['--no-colors'];
+	assert.equal(requireUncached('./'), false);
+});
+it('should return false if --no-colours flag is used', function () {
+	process.argv = ['--no-colours'];
 	assert.equal(requireUncached('./'), false);
 });
 
@@ -32,9 +44,17 @@ it('should return true if --color flag is used', function () {
 	process.argv = ['--color'];
 	assert.equal(requireUncached('./'), true);
 });
+it('should return true if --colour flag is used', function () {
+	process.argv = ['--colour'];
+	assert.equal(requireUncached('./'), true);
+});
 
 it('should return true if --colors flag is used', function () {
 	process.argv = ['--colors'];
+	assert.equal(requireUncached('./'), true);
+});
+it('should return true if --colours flag is used', function () {
+	process.argv = ['--colours'];
 	assert.equal(requireUncached('./'), true);
 });
 
@@ -52,13 +72,25 @@ it('should support `--color=true` flag', function () {
 	process.argv = ['--color=true'];
 	assert.equal(requireUncached('./'), true);
 });
+it('should support `--colour=true` flag', function () {
+	process.argv = ['--colour=true'];
+	assert.equal(requireUncached('./'), true);
+});
 
 it('should support `--color=always` flag', function () {
 	process.argv = ['--color=always'];
 	assert.equal(requireUncached('./'), true);
 });
+it('should support `--colour=always` flag', function () {
+	process.argv = ['--colour=always'];
+	assert.equal(requireUncached('./'), true);
+});
 
 it('should support `--color=false` flag', function () {
 	process.argv = ['--color=false'];
+	assert.equal(requireUncached('./'), false);
+});
+it('should support `--colour=false` flag', function () {
+	process.argv = ['--colour=false'];
 	assert.equal(requireUncached('./'), false);
 });


### PR DESCRIPTION
Added support for the user to be able to use the British "colour" spelling in env variables and in arguments to hopefully remove frustration when it doesn't work because they used the wrong spelling.