### PR TITLE
removed UPSTART_JOB test

### DIFF
--- a/test.js
+++ b/test.js
@@ -38,11 +38,6 @@ it('should return true if --colors flag is used', function () {
 	assert.equal(requireUncached('./'), true);
 });
 
-it('should return false if `UPSTART_JOB` is in env', function () {
-	process.env.UPSTART_JOB = true;
-	assert.equal(requireUncached('./'), false);
-});
-
 it('should return true if `COLORTERM` is in env', function () {
 	process.env.COLORTERM = true;
 	assert.equal(requireUncached('./'), true);


### PR DESCRIPTION
As per #21:

> The /UPSTART_JOB/ check was premature, and doesn't do the right thing.

This PR removes the test for it (needless test).